### PR TITLE
fix(upload): batch delete/uploads to avoid hangs

### DIFF
--- a/findus/InteractivePchipEditor.py
+++ b/findus/InteractivePchipEditor.py
@@ -17,7 +17,7 @@ except Exception as _:
 
 class InteractivePchipEditor:
     def __init__(self):
-         """
+        """
         Initialize the plot with control points, curve, and interactive elements.
         Sets up the figure, axes, data points, annotations, and event handlers.
         """

--- a/findus/helper/upload.py
+++ b/findus/helper/upload.py
@@ -7,29 +7,93 @@
 # If not, please write to: info@faultyhardware.de.
 
 import argparse
-import subprocess
 import os
 import sys
+import stat
 
-def upload(file:str, port:str):
+from findus.pyboard import Pyboard
+
+
+def connect(port: str, soft_reset: bool = False) -> Pyboard:
     try:
-        ret = subprocess.check_output(["ampy", "-p", port, "ls"])
-    except Exception as e:
+        pyb = Pyboard(port, wait=2)
+        pyb.enter_raw_repl(soft_reset=soft_reset)
+        return pyb
+    except Exception:
         print("[-] Pico Glitcher could not be found. Aborting.")
         sys.exit(-1)
+
+
+def list_remote_files(pyb: Pyboard) -> list[str]:
+    return [
+        entry.name
+        for entry in pyb.fs_listdir("")
+        if not stat.S_ISDIR(entry.st_mode)
+    ]
+
+
+def delete_files(pyb: Pyboard, filenames: list[str]):
+    if not filenames:
+        return
+    print(f"[+] Deleting files: {', '.join(filenames)}...")
+    for filename in filenames:
+        pyb.fs_rm(filename)
+
+
+def upload_files(pyb: Pyboard, files: list[str]):
+    if not files:
+        return
+    print(f"[+] Uploading files: {', '.join(files)}...")
+    for file in files:
+        pyb.fs_put(file, os.path.basename(file))
+
+
+def upload(file: str, port: str):
+    pyb = connect(port)
+    remote_files = list_remote_files(pyb)
     filename = os.path.basename(file)
-    if filename.encode() in ret:
+    if filename in remote_files:
         print(f"[+] Deleting {filename}...")
-        subprocess.call(["ampy", "-p", port, "rm", filename])
+        pyb.fs_rm(filename)
 
-    # upload the new script
     print(f"[+] Uploading {file}...")
-    subprocess.call(["ampy", "-p", port, "put", file])
+    pyb.fs_put(file, filename)
+    pyb.exit_raw_repl()
+    pyb.close()
 
-def reset(port:str):
-    # resetting
+
+def upload_files_batch(files: list[str], port: str):
+    pyb = connect(port)
+    remote_files = set(list_remote_files(pyb))
+
+    # delete all existing target files first (single connected session)
+    target_filenames = [os.path.basename(f) for f in files]
+    to_delete = [name for name in target_filenames if name in remote_files]
+    if to_delete:
+        delete_files(pyb, to_delete)
+
+    # then upload everything (single connected session)
+    upload_files(pyb, files)
+    pyb.exit_raw_repl()
+    pyb.close()
+
+
+def reset(port: str):
     print("[+] Resetting Raspberry Pi Pico...")
-    subprocess.call(["ampy", "-p", port, "reset"])
+    pyb = connect(port)
+    # Use no-follow execution because the board resets immediately.
+    pyb.exec_raw_no_follow("import machine\nmachine.reset()")
+    pyb.close()
+
+
+def print_remote_content(port: str):
+    pyb = connect(port)
+    print("[+] Content of the Raspberry Pi Pico:")
+    for filename in list_remote_files(pyb):
+        print(filename)
+    pyb.exit_raw_repl()
+    pyb.close()
+
 
 def main(argv=sys.argv):
     parser = argparse.ArgumentParser(
@@ -45,34 +109,33 @@ def main(argv=sys.argv):
     # reset before tasks to have a well defined state
     reset(args.port)
 
-    try:
-        ret = subprocess.check_output(["ampy", "-p", args.port, "ls"])
-    except Exception as _:
-        print("[-] Pico Glitcher could not be found. Aborting.")
-        sys.exit(-1)
+    pyb = connect(args.port)
+    remote_files = list_remote_files(pyb)
+    remote_file_set = set(remote_files)
+
     if args.delete_all:
         print("[+] Deleting all files...")
-        for filename in ret.decode().split():
-            subprocess.call(["ampy", "-p", args.port, "rm", filename[1:]])
+        delete_files(pyb, remote_files)
 
     if args.delete:
         filename = os.path.basename(args.delete)
-        if filename.encode() in ret:
+        if filename in remote_file_set:
             print(f"[+] Deleting {filename}...")
-            subprocess.call(["ampy", "-p", args.port, "rm", filename])
+            pyb.fs_rm(filename)
+
+    pyb.exit_raw_repl()
+    pyb.close()
 
     if args.file is not None:
-        upload(args.files, args.port)
+        upload(args.file, args.port)
         reset(args.port)
 
     if args.files is not None:
-        for f in args.files:
-            upload(f, args.port)
+        upload_files_batch(args.files, args.port)
         reset(args.port)
 
     # what is on the Raspberry Pi Pico?
-    print("[+] Content of the Raspberry Pi Pico:")
-    subprocess.call(["ampy", "-p", args.port, "ls"])
+    print_remote_content(args.port)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Changes

- replace repeated ampy subprocess calls with direct findus.pyboard API usage
- perform multi-file uploads in two phases within one connection:
  - delete matching remote files first
  - upload all requested files next
- keep reset behavior but issue reset via pyboard (machine.reset())
- add small connect wait (wait=2) to improve reliability after resets/reconnects
- print final remote file listing via pyboard
- fix --file path bug (was incorrectly passing args.files)
- bonus - fix bad indentation in InteractivePchipEditor

###  Before

```
$ upload --port /dev/ttyACM0 --files AD910X.py FastADC.py Globals.py PicoGlitcher.py PulseGenerator.py Spline.py Statemachines.py config_v2.1-2/config.json
[+] Resetting Raspberry Pi Pico...
[+] Deleting AD910X.py...
[+] Uploading AD910X.py...
<Hangs here>
```

###  After

```
$ upload --port /dev/ttyACM0 --files AD910X.py FastADC.py Globals.py PicoGlitcher.py PulseGenerator.py Spline.py Statemachines.py config_v2.1-2/config.json
[+] Resetting Raspberry Pi Pico...
[+] Deleting files: AD910X.py, FastADC.py, Globals.py, PicoGlitcher.py...
[+] Uploading files: AD910X.py, FastADC.py, Globals.py, PicoGlitcher.py, PulseGenerator.py, Spline.py, Statemachines.py, config_v2.1-2/config.json...
[+] Resetting Raspberry Pi Pico...
[+] Content of the Raspberry Pi Pico:
AD910X.py
FastADC.py
Globals.py
PicoGlitcher.py
PulseGenerator.py
Spline.py
Statemachines.py
config.json
globals.py
```

The firmware upload process runs very reliably and quickly now.