### PR TITLE
Implement a way to trigger on our own release of the reset line. WIP

### DIFF
--- a/findus/findus.py
+++ b/findus/findus.py
@@ -1195,6 +1195,9 @@ class PicoGlitcher(Glitcher):
         self.pico_glitcher.set_trigger("edge", pin_trigger, edge_type)
         self.pico_glitcher.set_number_of_edges(number_of_edges)
 
+    def self_trigger(self,pin_trigger:str = "default"):
+        self.pico_glitcher.set_trigger("self", pin_trigger)
+
     def set_cpu_frequency(self, frequency:int = 200_000_000):
         """
         Set the CPU frequency of the Raspberry Pi Pico.

--- a/findus/firmware/PicoGlitcher.py
+++ b/findus/firmware/PicoGlitcher.py
@@ -92,6 +92,7 @@ class PicoGlitcher():
         self.pin_glitch = self.pin_lpglitch
         # standard dead zone after power down
         self.dead_time = 0.0
+        self.wait_time = 0.0001
         self.pin_condition = self.pin_glitch_en
         self.condition = "rising"
         self.number_of_edges = 1
@@ -537,6 +538,12 @@ class PicoGlitcher():
             self.sm1.put(pattern)
             # push number of bits into the fifo of the statemachine (self.number_of_bits - 1 is an optimization here)
             self.sm1.put(self.number_of_bits - 1)
+            self.sm1.active(1)
+
+        elif self.trigger_mode == "self":
+            # without a trigger source, we trigger after we release the RESET line
+            self.sm1.init(Statemachines.self_trigger, freq=self.frequency, set_base=self.pin_reset)
+            self.sm1.put(int(self.wait_time * self.frequency))
             self.sm1.active(1)
 
         self.armed = True

--- a/findus/firmware/Statemachines.py
+++ b/findus/firmware/Statemachines.py
@@ -378,6 +378,22 @@ def uart_trigger():
     # wrap around # TODO: ist hier ein wrap überhaupt notwendig?
     jmp("start")
 
+@asm_pio(set_init=(PIO.OUT_LOW))
+def self_trigger():
+    # block until waittime received
+    pull(block)
+    mov(x, osr)
+
+    # wait for waittime ticks
+    label("wait_loop")
+    # decrease x and jump to the beginning of the loop
+    jmp(x_dec, "wait_loop")
+
+    # release reset line, and forward trigger
+    set(pins, 0b1)
+    irq(block, 1)
+    push(block)
+
 @asm_pio()
 def block_rising_condition():
     # block until dead time parameters received


### PR DESCRIPTION
Sorry for the lack of communication in https://github.com/MKesenheimer/fault-injection-library/issues/39

I have prepared a pull request to give an idea what I mean / what is now working for me. 

So to sum up the issue I am facing: 

My target does not have a nice timing anchor to glitch a read of fusebits in bootrom. Hence I want to trigger on the release of my reset line. That moment (release of reset) should also fire the IRQ to the glitch logic. Not sure what a proper name would be, I did come up with 'self-trigger'. 

I didn't want to change much in your logic without consulting and therefor did implement a delay ('wait_time') before the reset is released. This gives sufficient time to arm the target and not miss the trigger. Another (better?) option is skipping that 'wait_time' delay: 
1) Initialize trigger
2) Arm the target, send IRQ to trigger statemachine
3) Release reset, send IRQ to glitch statemachine
4) Do the glitch

Looking forward to your feedback.